### PR TITLE
fix: DND 소개 페이지 이미지 레이아웃 수정

### DIFF
--- a/apps/web/src/components/pages/AboutPage/index.module.scss
+++ b/apps/web/src/components/pages/AboutPage/index.module.scss
@@ -17,8 +17,8 @@
     position: relative;
 
     .image {
-      width: 100%;
-      height: auto;
+      width: auto;
+      height: 100%;
     }
 
     .image:last-of-type {


### PR DESCRIPTION
## What is this PR? :mag:

아이폰 최신 버전의 Chrome 및 Safari에서 이미지가 비정상적으로 표시되는 이슈를 수정했습니다.

해당 이미지는 기존에도 잘못 렌더링되고 있었지만, Chrome에서 이를 비교적 정상적으로 보정해 표시해주어 문제가 드러나지 않았습니다.
이번에 iPhone 환경에서 이미지가 비정상적으로 노출되는 현상을 확인했고, 이를 수정했습니다.

## Changes :memo:

## Screenshot :camera:

|AS-IS| TO-BE |
|-|-|
| <img width="829" height="955" alt="image" src="https://github.com/user-attachments/assets/a9dfe606-1d2b-489a-a840-787c9bd70111" /> | <img width="824" height="949" alt="image" src="https://github.com/user-attachments/assets/d020e903-d2fc-436d-9265-c5629d66304a" /> |
