### PR TITLE
chore: 브랜치 머지 정책 문서화 및 ruleset 코드화

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,49 @@
+# GitHub Branch Rulesets
+
+`main`, `develop` 브랜치의 머지 정책을 GitHub Rulesets 로 강제합니다.
+
+| 파일 | 적용 대상 | 허용 머지 방식 | 부가 보호 |
+|---|---|---|---|
+| `main.json` | `refs/heads/main` | **merge commit only** | branch 삭제 금지 |
+| `develop.json` | `refs/heads/develop` | **squash only** | branch 삭제 금지 |
+
+> 참고: GitHub 의 머지 방식 옵션(`Allow merge commits`, `Allow squash merging`, `Allow rebase merging`)은 **레포지토리 전역 설정**이라 브랜치별로 강제할 수 없습니다. 위 ruleset 의 `pull_request.allowed_merge_methods` 가 브랜치별 강제를 담당하므로, 레포 설정에서는 세 가지를 모두 켜둔 채로 두어도 ruleset 이 우선합니다.
+
+## 최초 적용
+
+GitHub CLI 로 적용합니다. `gh auth login` 으로 먼저 로그인하세요.
+
+```bash
+# 인증
+gh auth login
+
+# 적용 (레포 루트에서 실행)
+gh api -X POST \
+  -H "Accept: application/vnd.github+json" \
+  /repos/DNDACADEMY/dnd-academy-v2/rulesets \
+  --input .github/rulesets/main.json
+
+gh api -X POST \
+  -H "Accept: application/vnd.github+json" \
+  /repos/DNDACADEMY/dnd-academy-v2/rulesets \
+  --input .github/rulesets/develop.json
+```
+
+## 업데이트
+
+ruleset ID 를 먼저 확인한 뒤 `PUT` 으로 덮어씁니다.
+
+```bash
+# 1) 현재 ruleset 목록과 ID 확인
+gh api /repos/DNDACADEMY/dnd-academy-v2/rulesets
+
+# 2) ID 를 채워 업데이트 (예: 12345)
+gh api -X PUT \
+  -H "Accept: application/vnd.github+json" \
+  /repos/DNDACADEMY/dnd-academy-v2/rulesets/12345 \
+  --input .github/rulesets/main.json
+```
+
+## 권한
+
+리포지토리의 **Admin** 권한이 있어야 적용 가능합니다.

--- a/.github/rulesets/develop.json
+++ b/.github/rulesets/develop.json
@@ -1,0 +1,25 @@
+{
+  "name": "develop: squash merge only",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/develop"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": ["squash"],
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    { "type": "deletion" }
+  ]
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,25 @@
+{
+  "name": "main: merge commit only",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": ["merge"],
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    { "type": "deletion" }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+## 브랜치 전략
+
+```
+feature/* ─┐
+fix/*      ├─(Squash & Merge)─▶ develop ─(Create a merge commit)─▶ main
+chore/*    ┘
+```
+
+- **메인 브랜치는 `main`** — 항상 배포 가능한 상태
+- **개발 브랜치는 `develop`** — 모든 작업 브랜치의 통합 지점
+- **작업 브랜치**: `feature/*`, `fix/*`, `chore/*`, `refactor/*` 등 목적 prefix 사용
+
+## 머지 정책
+
+### 작업 브랜치 → `develop`
+
+- **Squash and merge 만 허용**
+- 커밋 제목 형식: `<type>: <description> (#<PR번호>)` (GitHub이 자동 생성)
+- PR 하나 = `develop` 위 커밋 하나로 정리되어 히스토리가 깨끗하게 유지됩니다.
+
+### `develop` → `main`
+
+- **Create a merge commit 만 허용** (rebase, squash 금지)
+- 머지 커밋이 "이 시점에 배포된 묶음"을 표시 → 릴리스 단위 추적·롤백이 쉬워집니다.
+- 머지 커밋 메시지는 기본값(`Merge pull request #N from DNDACADEMY/develop`) 유지.
+
+## 금지 사항
+
+`main`/`develop` 히스토리를 보호하기 위해 아래는 금지합니다.
+
+- `main` 에 **직접 push** 또는 **작업 브랜치 PR**
+- `main` → `develop` 역머지 (hotfix 포함, 아래 hotfix 흐름을 따를 것)
+- `develop` 에 force push, rebase merge
+- merge commit 메시지 자유 편집 (자동 메시지 유지)
+
+## Hotfix 절차
+
+긴급 패치도 `main` 에 직접 작업하지 않습니다.
+
+1. `develop` 에서 `fix/hotfix-*` 브랜치 생성
+2. PR 을 `develop` 으로 올리고 **Squash & Merge**
+3. `develop` → `main` PR 을 즉시 생성하고 **Create a merge commit**
+
+## 커밋 메시지 컨벤션
+
+PR 제목(= squash 커밋 제목) 기준으로 다음 prefix 를 사용합니다.
+
+- `feat:` 새 기능
+- `fix:` 버그 수정
+- `chore:` 빌드/설정/정보 업데이트
+- `refactor:` 리팩터링
+- `docs:` 문서
+- `style:` 코드 스타일 (포맷팅 등)
+- `test:` 테스트


### PR DESCRIPTION
## What is this PR? :mag:

브랜치 머지 정책을 문서로 명문화하고, GitHub Branch Ruleset 설정을 코드(JSON)로 버전 관리합니다.

## Changes :memo:

- **`CONTRIBUTING.md` 신규**
  - 작업 브랜치 → `develop`: **Squash & Merge** 만 허용
  - `develop` → `main`: **Create a merge commit** 만 허용
  - hotfix 절차, 금지 사항, 커밋 컨벤션 정리
- **`.github/rulesets/` 신규**
  - `main.json`: `allowed_merge_methods: ["merge"]` + `deletion` 보호
  - `develop.json`: `allowed_merge_methods: ["squash"]` + `deletion` 보호
  - `README.md`: 적용/업데이트용 `gh` 명령 안내

## 참고

- 실제 라이브 ruleset 은 이미 동일하게 적용되어 있음 (ID `15055331`, `15055311`)
- 이 PR 은 해당 설정을 코드로 박제 + 사람용 규칙을 문서화하는 용도
- `non_fast_forward` (force push 금지) 는 의도적으로 제외 — 운영 편의 우선

## Screenshot :camera:

N/A (docs/config only)
