### PR TITLE
chore: 15기 모집 일정 반영 (status UPCOMING)

### DIFF
--- a/apps/web/src/lib/assets/data/event_status.json
+++ b/apps/web/src/lib/assets/data/event_status.json
@@ -1,6 +1,6 @@
 {
-  "status": "INACTIVE",
-  "applicationStartDateTime": "2025/11/17 00:00:00",
-  "applicationEndDateTime": "2025/12/07 23:59:59",
-  "applicantAcceptanceDateTime": "2025/12/21 00:00:00"
+  "status": "UPCOMING",
+  "applicationStartDateTime": "2026/06/01 00:00:00",
+  "applicationEndDateTime": "2026/06/14 23:59:59",
+  "applicantAcceptanceDateTime": "2026/07/04 00:00:00"
 }

--- a/apps/web/src/lib/constants/index.ts
+++ b/apps/web/src/lib/constants/index.ts
@@ -1,6 +1,13 @@
-export const CURRENT_FLAG = 14;
+import { EventStatusType } from '@dnd-academy/core';
 
-export const NEXT_FLAG = CURRENT_FLAG + 1;
+import { eventStatusData } from '../assets/data';
+
+const { status } = eventStatusData as { status: EventStatusType };
+
+export const CURRENT_FLAG = 15;
+
+// NOTE: UPCOMING은 현재 기수이므로 0, 나머지는 다음기수로 1씩 증가
+export const NEXT_FLAG = CURRENT_FLAG + (status === 'UPCOMING' ? 0 : 1);
 
 export const DEVELOPER_APPLICATION_LINK = 'https://forms.gle/XWCQkdCRfw8pNam97';
 


### PR DESCRIPTION
## Summary
- 14기 종료 후 비어있던 `event_status.json`을 15기 일정으로 업데이트
- status: `INACTIVE` → `UPCOMING` (지원 시작 전)
- 지원 시작: `2026/06/01 00:00:00`
- 지원 마감: `2026/06/14 23:59:59`
- 활동 시작(OT): `2026/07/04 00:00:00`

## Test plan
- [ ] 로컬에서 홈페이지 상단 status/일정 노출 확인
- [ ] 지원 시작 전(현재 시점) UPCOMING 라벨 정상 렌더링 확인
