### PR TITLE
fix: applicant-count.json placeholder 커밋하여 Vercel 빌드 ENOENT 해결

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -54,4 +54,3 @@ cypress/log
 
 # google spreadsheet
 dist/
-src/lib/assets/data/applicant-count.json

--- a/apps/web/src/lib/assets/data/applicant-count.json
+++ b/apps/web/src/lib/assets/data/applicant-count.json
@@ -1,0 +1,6 @@
+{
+  "developer": 0,
+  "designer": 0,
+  "total": 0,
+  "lastUpdated": ""
+}


### PR DESCRIPTION
## Summary
- `apps/web/src/lib/assets/data/applicant-count.json`을 gitignore에서 제외하고 0 기본값 placeholder를 커밋
- Vercel 빌드에서 `generate:applicant-count`가 실행되지 않은 채 `next build`가 import를 시도해 `ENOENT: no such file or directory` 로 빌드가 깨지던 문제를 막기 위함
- 빌드 시 `yarn generate:applicant-count`가 정상 동작하면 실제 값으로 덮어쓰는 흐름은 그대로 유지

## Background
- 기존에는 해당 JSON이 Google Spreadsheet에서 생성되는 산출물이라는 이유로 `apps/web/.gitignore`에 포함되어 있었음
- 그러나 파일이 부재한 상태에서 `apps/web/src/lib/assets/data/index.ts`가 정적 import 하기 때문에, 빌드 환경에서 generate 단계가 누락되면 빌드 자체가 실패
- 노출되는 데이터는 숫자 4개(`developer`, `designer`, `total`, `lastUpdated`)뿐이며, 이미 홈 SSR(`apps/web/src/app/page.tsx`)에서 그대로 렌더되어 사실상 공개 정보

## Notes / Follow-ups
- 이제 파일이 추적되므로 로컬 `yarn build` 시 generate 스크립트가 실제 값으로 덮어써서 `git status`에 modified로 잡힘. 개별 개발자는 필요 시 `git update-index --skip-worktree apps/web/src/lib/assets/data/applicant-count.json` 으로 우회 가능
- Vercel 환경에서 `generate:applicant-count`가 실제로 실행되는지(turbo 설정, `GOOGLE_PRIVATE_KEY` / `GOOGLE_CLIENT_EMAIL` env 유무) 별도 확인 필요. 안 돌 경우 빌드는 통과하지만 홈에 "0명"으로 노출됨

## Test plan
- [ ] CI 빌드(Vercel preview)에서 ENOENT 없이 빌드 성공 확인
- [ ] preview 배포 후 홈 상단 지원자 수가 의도한 값으로 노출되는지 확인 (Vercel env 설정에 따라 0 또는 실제 값)
- [x] 로컬에서 `yarn build` 시 generate 스크립트가 placeholder를 덮어쓰고 정상 빌드되는지 확인
