### PR TITLE
fix: 이탈자 표시 지난 기수로 표시되도록 수정

### DIFF
--- a/apps/web/src/components/organisms/CounterCardSection/index.tsx
+++ b/apps/web/src/components/organisms/CounterCardSection/index.tsx
@@ -33,7 +33,7 @@ async function CounterCardSection({ title: sectionTitle }: Props) {
       count: totalProjects, title: '총 프로젝트 수', color: 'red', suffix: '개',
     },
     {
-      count: dropouts, title: `${CURRENT_FLAG}기 이탈자`, color: 'green', highlight: true,
+      count: dropouts, title: `${CURRENT_FLAG - 1}기 이탈자`, color: 'green', highlight: true,
     },
   ];
 


### PR DESCRIPTION
## What is this PR? :mag:

현재 15기의 경우 14기로 표기되도록 수정해요.

| AS-IS | TO-BE |
|-|-|
| <img width="1207" height="421" alt="image" src="https://github.com/user-attachments/assets/4e8c9a2f-dea6-4718-a615-60b14a75a7d2" /> | <img width="1178" height="226" alt="image" src="https://github.com/user-attachments/assets/db465d85-892e-4524-accc-092411d5d2a8" /> |

## Changes :memo:

## Screenshot :camera:
