### PR TITLE
chore(admin): next-env.d.ts triple-slash 처리

### DIFF
--- a/apps/admin/.eslintrc.js
+++ b/apps/admin/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   ignorePatterns: [
     'public/',
     '/.next',
+    'next-env.d.ts',
   ],
   extends: [
     '@dnd-academy/eslint-config',

--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What is this PR? :mag:

apps/web에 들어간 next-env.d.ts 처리(PR #361)와 동일한 변경을 apps/admin에도 적용합니다. typedRoutes 활성화로 Next.js 15.5가 자동 삽입하는 triple-slash path reference 때문에 ESLint(`@typescript-eslint/triple-slash-reference`)가 매번 깨지는 걸 막습니다.

## Changes :memo:

- `apps/admin/next-env.d.ts`: Next.js가 재생성한 `/// <reference path="./.next/types/routes.d.ts" />` 라인 반영 (`# NOTE: This file should not be edited` 명시되어 있으므로 그대로 커밋)
- `apps/admin/.eslintrc.js`: `ignorePatterns`에 `next-env.d.ts` 추가 — apps/web과 동일한 방식

## Screenshot :camera:

N/A

## Test plan
- [ ] `yarn workspace admin lint` 통과 (triple-slash 경고 없음)
- [ ] `yarn workspace admin build` 정상