### PR TITLE
chore(ci): dependabot ignore 리스트 보강 + dead pattern 제거

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,6 @@ updates:
           - "jest"
           - "jest-*"
           - "@testing-library/*"
-          - "@types/jest*"
       storybook:
         patterns:
           - "storybook"
@@ -49,10 +48,21 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@storybook/*"
         update-types: ["version-update:semver-major"]
+      # `@storybook/*` glob does not match the bare `storybook` meta-package.
+      - dependency-name: "storybook"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "cypress"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # Bumping react-pdf 9 -> 10 reintroduces a runtime crash on /projects/[id]
+      # (pdfjs-dist 5.x + Next.js's bundled webpack 5.98.0, see PR #370 revert).
+      # tsc + lint do not catch it. Remove once Next.js bundles webpack >= 5.103.0.
+      - dependency-name: "react-pdf"
+        update-types: ["version-update:semver-major"]
+      # webpack is exact-pinned via root resolutions to match Next.js's bundled
+      # version; any dependabot bump is a silent no-op (manifest changes only).
+      - dependency-name: "webpack"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## 요약

PR #370 (`d025909`)의 ultrareview에서 짚인 `dependabot.yml` 이슈 두 건을 반영합니다. ignore 리스트에 누락된 3개 패키지를 추가하고, testing 그룹의 도달 불가 패턴 1개를 제거합니다.

## 배경

PR #370으로 `.github/dependabot.yml`을 도입한 직후 ultrareview에서 두 가지 문제 지적:

### Finding 1 (normal) — ignore 리스트 누락 3건

1. **`react-pdf`** ⚠️ 가장 위험. PR #370의 마지막 커밋(`9e032e6`)이 react-pdf 9 → 10 bump을 revert. 이유는 pdfjs-dist 5.x + Next.js 번들 webpack 5.98.0의 호환 버그 (`Object.defineProperty called on non-object`, [vercel/next.js#89177](https://github.com/vercel/next.js/issues/89177)). **tsc + lint는 통과**하고 runtime `/projects/[id]`에서만 크래시. 그대로 두면 다음 월요일에 dependabot이 똑같은 bump PR을 만들고, 녹색 CI를 보고 무심코 머지될 가능성.

2. **bare `storybook`** — `@storybook/*` glob이 bare 메타 패키지 매칭 못 함. `apps/web/package.json:111`, `packages/ui/package.json:106` 두 곳에 `"storybook": "8.6.17"` devDep 박혀있음. storybook 그룹은 `update-types: [patch, minor]`로 제한돼 major는 그룹에서 제외 → 개별 PR로 새어 나옴.

3. **`webpack`** — root resolutions가 `"webpack": "5.98.0"` exact-pin. 어떤 dependabot bump도 resolution이 덮어써서 manifest만 바뀌고 lockfile은 그대로인 no-op PR이 됨. 리뷰 노이즈.

### Finding 2 (nit) — dead pattern

`testing` 그룹의 `@types/jest*` 패턴은 위쪽 `types` 그룹의 `@types/*` 캐치올이 먼저 매칭해서 도달 불가. dependabot은 [첫 매칭 그룹에만 추가](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)하므로 testing 그룹에 적어둬도 효과 없었음.

## 변경 내용

```diff
       testing:
         patterns:
           - "jest"
           - "jest-*"
           - "@testing-library/*"
-          - "@types/jest*"

     ignore:
       ... (기존 항목 유지)
       - dependency-name: "@storybook/*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "storybook"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "cypress"
       ...
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "react-pdf"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "webpack"
```

각 추가 항목 위에 *왜 ignore하는지 + 언제 제거할 수 있는지* 주석 동봉.

## 제거 조건

| 항목 | 제거 조건 |
|---|---|
| `react-pdf` major ignore | Next.js가 webpack ≥ 5.103.0 번들 → pdfjs-dist 5.x 안전해짐 |
| `storybook` major ignore | Storybook 9.x major 호환 검증 후 별도 PR로 bump |
| `webpack` 전체 ignore | root resolutions의 exact-pin 해제 시 |
| (dead pattern 제거) | 회복 불필요, 영구 제거 |

## Test plan

- [x] YAML 문법 자체 검증은 GitHub Actions의 dependabot 파서가 머지 후 자동 수행
- [ ] **머지 후 확인:** 다음 주 월요일 09:00 KST 첫 배치 PR에서 react-pdf/storybook/webpack 관련 자동 PR 없는지 확인
