### PR TITLE
chore: 웹 런타임 안정성 개선과 TS/Next 설정 정리

### DIFF
--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+next-env.d.ts
 
 # production
 /build

--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+next-env.d.ts
 
 # production
 /build

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { Preview } from "@storybook/react";
 
 import '@dnd-academy/ui/style.css';

--- a/apps/web/__mocks__/svg.tsx
+++ b/apps/web/__mocks__/svg.tsx
@@ -1,6 +1,6 @@
-import React, { SVGProps } from 'react';
+import { forwardRef, SVGProps } from 'react';
 
-const SvgrMock = React.forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>((props, ref) => (
+const SvgrMock = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>((props, ref) => (
   <svg ref={ref} {...props} />
 ));
 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/components/atoms/ResponsiveMasonry/index.tsx
+++ b/apps/web/src/components/atoms/ResponsiveMasonry/index.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react';
 // TODO - 걷어내기
 import Masonry, { ResponsiveMasonry as ReactResponsiveMasonry } from 'react-responsive-masonry';
 
+import { useIsMounted } from '@dnd-academy/ui/client';
 import clsx from 'clsx';
 
 import styles from './index.module.scss';
@@ -13,6 +14,16 @@ type Props = {
 };
 
 function ResponsiveMasonry({ children, className }: PropsWithChildren<Props>) {
+  const isMounted = useIsMounted();
+
+  if (!isMounted) {
+    return (
+      <div className={clsx(styles.wrapper, className)}>
+        {children}
+      </div>
+    );
+  }
+
   return (
     <ReactResponsiveMasonry
       columnsCountBreakPoints={{ 350: 1, 720: 2, 900: 3 }}

--- a/apps/web/src/components/molecules/Modal/components/ModalOpenButton/index.tsx
+++ b/apps/web/src/components/molecules/Modal/components/ModalOpenButton/index.tsx
@@ -10,6 +10,7 @@ function ModalOpenButton({
 } : { children: ReactElement<ButtonHTMLAttributes<HTMLButtonElement>> }) {
   const { toggle } = useModalContext();
 
+  // NOTE - cloneElement로 자식 버튼에 모달 오픈 동작을 주입하는 계약입니다. 변경 시 기존 onClick 합성 동작을 함께 확인해야 합니다.
   return cloneElement(child, {
     onClick: (e: MouseEvent<HTMLButtonElement>) => {
       toggle(true);

--- a/apps/web/src/components/molecules/Modal/components/ModalProvider/index.tsx
+++ b/apps/web/src/components/molecules/Modal/components/ModalProvider/index.tsx
@@ -4,7 +4,7 @@ import {
 
 type ModalContextType = { open: boolean; toggle: Dispatch<SetStateAction<boolean>>; };
 
-const ModalContext = createContext<ModalContextType>({} as ModalContextType);
+const ModalContext = createContext<ModalContextType | null>(null);
 
 export const useModalContext = () => {
   const context = useContext(ModalContext);

--- a/apps/web/src/components/molecules/ShareClipBoardCTA/index.tsx
+++ b/apps/web/src/components/molecules/ShareClipBoardCTA/index.tsx
@@ -1,19 +1,24 @@
 'use client';
 
 import {
-  ButtonHTMLAttributes, cloneElement, MouseEvent, ReactElement,
+  ButtonHTMLAttributes, cloneElement, isValidElement, MouseEvent, type ReactElement,
 } from 'react';
 
 import useClipboard from '@/hooks/useClipboard';
 
 type Props = {
   shareText: string;
-  children: ReactElement<ButtonHTMLAttributes<HTMLButtonElement>>;
+  children?: ReactElement<ButtonHTMLAttributes<HTMLButtonElement>>;
 };
 
 function ShareClipBoardCTA({ shareText, children: child }: Props) {
   const onClickShare = useClipboard();
 
+  if (!isValidElement<ButtonHTMLAttributes<HTMLButtonElement>>(child)) {
+    return null;
+  }
+
+  // NOTE - cloneElement로 자식 버튼에 클립보드 복사 동작을 주입하는 계약입니다. 변경 시 기존 onClick 합성 동작을 함께 확인해야 합니다.
   return cloneElement(child, {
     onClick: (e: MouseEvent<HTMLButtonElement>) => {
       onClickShare(shareText);

--- a/apps/web/src/components/organisms/ApplyModal/index.tsx
+++ b/apps/web/src/components/organisms/ApplyModal/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { cloneElement, ReactElement } from 'react';
+import {
+  cloneElement, isValidElement, type ReactElement, type ReactNode,
+} from 'react';
 
 import { Button, ButtonProps } from '@dnd-academy/ui';
 
@@ -10,17 +12,27 @@ import { CURRENT_FLAG, DESIGNER_APPLICATION_LINK, DEVELOPER_APPLICATION_LINK } f
 import styles from './index.module.scss';
 
 type Props = {
-  children: ReactElement<ButtonProps>;
+  children?: ReactElement<ButtonProps>;
 };
 
 function ApplyModal({ children: child }: Props) {
+  if (!isValidElement<ButtonProps>(child)) {
+    return null;
+  }
+
+  const label = <span key="default-label">{`${CURRENT_FLAG}기 지원하기`}</span>;
+  const children: ReactNode = child.props.children ? (
+    <>
+      {label}
+      {child.props.children}
+    </>
+  ) : label;
+
   return (
     <Modal>
       <Modal.OpenButton>
-        {cloneElement(child, child.props, [
-          <span key="default-label">{`${CURRENT_FLAG}기 지원하기`}</span>,
-          child.props.children,
-        ])}
+        {/* NOTE - cloneElement로 지원 모달 오픈 동작과 기본 라벨을 주입하는 계약입니다. 변경 시 버튼 클릭 플로우를 함께 확인해야 합니다. */}
+        {cloneElement(child, child.props, children)}
       </Modal.OpenButton>
       <Modal.ContentsBase title={`${CURRENT_FLAG}기 지원하기`} size="small">
         <div className={styles.contentsWrapper}>

--- a/apps/web/src/components/organisms/ApplyNotifyButtonGroup/index.tsx
+++ b/apps/web/src/components/organisms/ApplyNotifyButtonGroup/index.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { cloneElement, ReactElement } from 'react';
+import {
+  cloneElement, isValidElement, type ReactElement, type ReactNode,
+} from 'react';
 
 import type { EventStatus } from '@dnd-academy/core';
 import type { ButtonProps } from '@dnd-academy/ui';
+import { useIsMounted } from '@dnd-academy/ui/client';
 
 import useCountdown from '@/hooks/useCountdown';
 import { CURRENT_FLAG, NEXT_COHORT_NOTIFICATION_URL, NEXT_FLAG } from '@/lib/constants';
@@ -11,11 +14,12 @@ import { CURRENT_FLAG, NEXT_COHORT_NOTIFICATION_URL, NEXT_FLAG } from '@/lib/con
 import ApplyModal from '../ApplyModal';
 
 type Props = {
-  children: ReactElement<ButtonProps>;
+  children?: ReactElement<ButtonProps>;
   eventStatus: EventStatus;
 };
 
 function ApplyNotifyButtonGroup({ children: child, eventStatus }: Props) {
+  const isMounted = useIsMounted();
   const {
     applicationStartDateTime, applicationEndDateTime,
   } = eventStatus;
@@ -25,17 +29,29 @@ function ApplyNotifyButtonGroup({ children: child, eventStatus }: Props) {
 
   const visibleApplyButton = applicationStartDateCountdown === 'END' && applicationEndDateCountdown !== 'END';
 
+  if (!isMounted || !isValidElement<ButtonProps>(child)) {
+    return null;
+  }
+
   if (!visibleApplyButton) {
+    const label = (
+      <span key="default-label">{`${applicationStartDateCountdown === 'END' ? NEXT_FLAG : CURRENT_FLAG}기 알림 신청하기`}</span>
+    );
+    const children: ReactNode = child.props.children ? (
+      <>
+        {label}
+        {child.props.children}
+      </>
+    ) : label;
+
     return (
       <>
+        {/* NOTE - cloneElement로 알림 신청 링크 속성과 라벨을 주입하는 계약입니다. 변경 시 CTA 이동/표시 상태를 함께 확인해야 합니다. */}
         {cloneElement(child, {
           ...child.props,
           isExternalLink: true,
           href: NEXT_COHORT_NOTIFICATION_URL,
-        }, [
-          <span key="default-label">{`${applicationStartDateCountdown === 'END' ? NEXT_FLAG : CURRENT_FLAG}기 알림 신청하기`}</span>,
-          child.props.children,
-        ])}
+        }, children)}
       </>
     );
   }

--- a/apps/web/src/components/organisms/ShareAlarmSection/index.tsx
+++ b/apps/web/src/components/organisms/ShareAlarmSection/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CSSProperties } from 'react';
 import Marquee from 'react-fast-marquee';
 

--- a/apps/web/src/components/pages/OrganizerPage/index.tsx
+++ b/apps/web/src/components/pages/OrganizerPage/index.tsx
@@ -60,6 +60,7 @@ function OrganizerPage({ organizer }: Props) {
                       width="0"
                       height="0"
                       sizes="(max-width: 1204px) 50vw, 33vw"
+                      priority
                     />
                   )}
               </div>

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -18,6 +18,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
     ".next/types/**/*.ts",
     "../../jest.setup.ts"
   ],

--- a/packages/ui/__mocks__/svg.tsx
+++ b/packages/ui/__mocks__/svg.tsx
@@ -1,6 +1,6 @@
-import React, { SVGProps } from 'react';
+import { forwardRef, SVGProps } from 'react';
 
-const SvgrMock = React.forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>((props, ref) => (
+const SvgrMock = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>((props, ref) => (
   <svg ref={ref} {...props} />
 ));
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,7 +18,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "noImplicitAny": true,
     "strictNullChecks": true,
     "baseUrl": "./",


### PR DESCRIPTION
## What changed

- `/reviews`에서 `react-responsive-masonry`가 hydration 단계에 SSR/CSR 렌더 차이를 만들 수 있어, 마운트 전에는 정적 wrapper로 렌더링한 뒤 클라이언트에서 masonry를 활성화하도록 정리했습니다.
- `ModalProvider` 기본 context를 `null`로 바꿔 provider 밖 사용 시 기존 guard가 실제로 동작하도록 수정했습니다.
- 운영진 상세 대표 이미지에 `priority`를 추가해 LCP 후보 이미지 경고를 줄였습니다.
- 이전 런타임 크래시 방지를 위해 client boundary, `cloneElement` 대상 가드, NOTE 주석을 함께 포함했습니다.

## Why

로컬 dev 환경에서 fatal overlay는 줄었지만, hydration warning 가능성, provider 누락 감지 실패, LCP 경고가 남아 있어 develop 기준 PR로 후속 개선합니다.

## Validation

- Pre-commit hook passed: `eslint-web`
- Pre-commit hook passed: `test-related` (`turbo test:coverage`, 5 tasks successful)

## Notes

- `apps/admin/next-env.d.ts`, `apps/web/next-env.d.ts`는 dev 서버가 변경한 generated file로 보여 PR 커밋에는 포함하지 않았습니다.
