### PR TITLE
ci: Chromatic 관련 파일 변경 시에만 Chromatic publish 체인 실행

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,30 @@ env:
   DEFAULT_YARN_VERSION: "4.3.1"
 
 jobs:
+  job_changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      chromatic: ${{ steps.filter.outputs.chromatic }}
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v6
+
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            chromatic:
+              - '.github/workflows/ci.yml'
+              - 'yarn.lock'
+              - 'package.json'
+              - 'apps/web/.storybook/**'
+              - 'apps/web/src/**'
+              - 'apps/web/package.json'
+              - 'packages/ui/**'
+              - 'packages/core/**'
+
   job_install_dependencies:
     name: Install Dependencies
     runs-on: ubuntu-latest
@@ -92,7 +116,8 @@ jobs:
 
   job_packages_build:
     name: Build
-    needs: [job_install_dependencies]
+    needs: [job_install_dependencies, job_changes]
+    if: needs.job_changes.outputs.chromatic == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -150,7 +175,8 @@ jobs:
 
   job_generate_data:
     name: Generate Data
-    needs: [job_install_dependencies, job_packages_build]
+    needs: [job_install_dependencies, job_packages_build, job_changes]
+    if: needs.job_changes.outputs.chromatic == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out current commit (${{ github.sha }})
@@ -242,7 +268,8 @@ jobs:
   #       run: yarn test:coverage
 
   job_publish_storybook_chromatic:
-    needs: [job_install_dependencies, job_packages_build, job_generate_data]
+    needs: [job_install_dependencies, job_packages_build, job_generate_data, job_changes]
+    if: needs.job_changes.outputs.chromatic == 'true'
     name: Chromatic Publish
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Chromatic publish 체인(build → generate data → publish)을 변경된 파일이 Chromatic 관련 경로에 포함될 때만 실행하도록 조건부로 전환했습니다.
- `dorny/paths-filter@v3` 기반의 `job_changes` 가드 잡을 추가해 PR/푸시 단위로 변경 경로를 한 번만 감지합니다.
- 무관한 변경에서는 세 잡이 한꺼번에 skip되므로 `needs:` 체인이 깨지지 않습니다. `Install Dependencies`와 `Format Check`는 그대로 항상 실행됩니다.

### 감시 대상 경로

- `.github/workflows/ci.yml`, `yarn.lock`, 루트 `package.json`
- `apps/web/.storybook/**`, `apps/web/src/**`, `apps/web/package.json`
- `packages/ui/**`, `packages/core/**`

## Test plan

- [x] PR 생성 후 `Detect Changes` 잡이 실행되고 `chromatic` 출력이 `true`인지 확인 (이 PR은 `ci.yml`을 수정했으므로 true여야 합니다)
- [x] `Build` / `Generate Data` / `Chromatic Publish` 잡이 정상적으로 실행되어 통과하는지 확인
- [x] 머지 후, Chromatic과 무관한 파일만 수정한 후속 PR에서 위 세 잡이 모두 `Skipped` 상태로 표시되는지 확인
- [x] (옵션) 브랜치 보호 규칙에서 `Chromatic Publish`가 필수 체크라면 skip 처리로 인해 머지가 막히지 않는지 확인하고, 필요 시 필수 체크에서 제외
