### PR TITLE
chore(ci): dependabot 의존성 그룹을 2-버킷으로 통합

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,30 +15,17 @@ updates:
       prefix-development: "chore"
       include: "scope"
     groups:
-      types:
-        patterns:
-          - "@types/*"
-      eslint:
-        patterns:
-          - "eslint"
-          - "eslint-*"
-          - "@typescript-eslint/*"
-      stylelint:
-        patterns:
-          - "stylelint"
-          - "stylelint-*"
-      testing:
-        patterns:
-          - "jest"
-          - "jest-*"
-          - "@testing-library/*"
-      storybook:
-        patterns:
-          - "storybook"
-          - "@storybook/*"
+      # devDependencies는 메이저 포함 한 PR로 묶는다. 런타임 번들에 영향이
+      # 없어 무더기로 열리는 것만 막으면 충분하다.
+      development-dependencies:
+        dependency-type: "development"
+      # 런타임 의존성은 minor/patch만 묶는다. 메이저는 개별 PR로 남겨
+      # (react-query 등) 동작 검증 후 단독 머지하도록 한다.
+      production-dependencies:
+        dependency-type: "production"
         update-types:
-          - "patch"
           - "minor"
+          - "patch"
     ignore:
       - dependency-name: "next"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 배경

Dependabot이 한 번에 6개의 의존성 PR을 열어(#393~#398) 리뷰 부담이 컸습니다. 원인은 dev 의존성 그룹이 `types/eslint/stylelint/testing/storybook` 5개로 잘게 쪼개져 있고, 런타임 의존성(@tanstack/react-query 등)은 **그룹이 없어 개별 PR로 쏟아지기** 때문입니다.

## 변경

npm 그룹을 **2-버킷 구조**로 통합했습니다.

| 그룹 | 대상 | 효과 |
|------|------|------|
| `development-dependencies` | 모든 devDependencies (메이저 포함) | dev 업데이트가 PR 1개로 통합 |
| `production-dependencies` | 런타임 의존성 minor/patch | react-query 등이 한 PR로 묶임 |
| (그룹 없음) | 런타임 **메이저** | 검토가 필요하므로 개별 PR 유지 |

기존 `ignore` 규칙(next/react/storybook major, react-pdf, webpack 등), 주간 스케줄, github-actions 섹션은 그대로 유지했습니다.

## 효과

매주 npm 기준 최대 2개(dev 묶음 + prod minor/patch 묶음) + 가끔 런타임 메이저 개별 PR로 줄어듭니다.

> 이미 열려 있는 #393~#398에는 소급 적용되지 않고, **다음 Dependabot 실행분부터** 적용됩니다.
