### PR TITLE
docs(skill): 모집 오픈 후속 안내에 서비스 계정 시트 공유 절차 명시

### DIFF
--- a/.claude/skills/cohort-open/SKILL.md
+++ b/.claude/skills/cohort-open/SKILL.md
@@ -110,8 +110,13 @@ description: DND 신규 기수 모집 오픈 시점에 지원 폼/시트 정보(
   applicantAcceptanceDateTime: 2026/06/22 00:00:00
 
 📦 후속 작업:
-1. 응답시트 ID를 바꿨다면 서비스 계정(GOOGLE_CLIENT_EMAIL)에 새 시트 공유 권한 확인
-   (안 그러면 generate-applicant-count 스크립트가 권한 에러로 실패)
+1. 응답시트 ID를 바꿨다면 새 스프레드시트 2개(개발자/디자이너)에 서비스 계정을
+   **뷰어(읽기) 이상 권한으로 공유(초대)** 했는지 운영진에게 확인 요청.
+   - 공유할 계정(GOOGLE_CLIENT_EMAIL):
+     dnd-academy@dnd-academy-admin-429806.iam.gserviceaccount.com
+   - 각 스프레드시트 우상단 [공유] → 위 이메일 추가 → 뷰어 권한으로 저장
+   - 안 그러면 generate-applicant-count 스크립트가 권한 에러로 실패해
+     홈페이지 실시간 지원자 수 집계가 깨짐
 2. 커밋 & PR
    git add apps/web/src/lib/constants/index.ts \
            apps/web/scripts/generate-applicant-count.ts \

--- a/.claude/skills/recruitment-open/SKILL.md
+++ b/.claude/skills/recruitment-open/SKILL.md
@@ -148,9 +148,12 @@ generate-applicant-count.ts:
 다음 단계 안내:
 - 모집 시작 시점에 event-status-update 스킬로 status를 ONGOING으로 전환
   (또는 두 작업을 묶어 처리하려면 `cohort-open` 오케스트레이터를 사용)
-- 응답시트 ID를 바꿨다면 서비스 계정(GOOGLE_CLIENT_EMAIL)이 새 시트에
-  공유돼 있는지 운영진에게 확인 요청 (안 그러면 generate-applicant-count
-  스크립트가 권한 에러로 실패)
+- 응답시트 ID를 바꿨다면 새 스프레드시트(개발자/디자이너)에 서비스 계정을
+  뷰어(읽기) 이상 권한으로 공유(초대)했는지 운영진에게 확인 요청.
+  공유 대상 GOOGLE_CLIENT_EMAIL:
+  dnd-academy@dnd-academy-admin-429806.iam.gserviceaccount.com
+  (각 시트 [공유] → 위 이메일 추가 → 뷰어 권한. 안 그러면
+  generate-applicant-count 스크립트가 권한 에러로 실패)
 ```
 
 ## 주의사항


### PR DESCRIPTION
## 작업 내용

모집 오픈 운영 스킬의 **후속 작업 안내**를 구체화합니다. 기존에는 "서비스 계정(GOOGLE_CLIENT_EMAIL)이 새 시트에 공유돼 있는지 확인"이라는 추상적 안내라, 실제로 누구를 어떤 권한으로 초대해야 하는지 매번 다시 찾아야 했습니다.

### 변경 스킬

- `.claude/skills/recruitment-open/SKILL.md`
- `.claude/skills/cohort-open/SKILL.md`

### 무엇이 바뀌나

- 공유 대상 이메일 명시: `dnd-academy@dnd-academy-admin-429806.iam.gserviceaccount.com`
- 절차 구체화: 각 스프레드시트 **[공유] → 위 이메일 추가 → 뷰어(읽기) 권한**
- 개발자/디자이너 **두 시트 모두** 공유해야 함을 명시
- 누락 시 결과(`generate-applicant-count` 권한 에러 → 홈페이지 지원자 수 집계 깨짐)는 그대로 유지

> 스크립트는 row 수만 읽으므로 **뷰어(읽기) 권한이면 충분**하다는 점도 안내에 반영했습니다.

## 참고

- 코드/동작 변경 없음. 운영 스킬 문서만 수정합니다.
- 15기 폼/응답시트 연결은 별도 PR(#401)에서 진행했고, 이 PR은 그 작업 중 발견한 안내 미흡을 보강하는 후속입니다.
