### PR TITLE
chore(ci): dependabot에서 next/Storybook 계열 자동 업데이트 차단

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,17 +27,22 @@ updates:
           - "minor"
           - "patch"
     ignore:
+      # next-upgrade.test.ts 가드레일이 next / @next/* 를 정확한 버전(16.2.x)으로
+      # 핀 고정한다. patch 까지 포함해 모든 자동 업데이트를 막고, 올릴 때는
+      # 가드레일 테스트를 함께 갱신하며 수동으로 진행한다.
       - dependency-name: "next"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: "@next/*"
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # Storybook 계열도 동일하게 가드레일이 정확한 버전(10.4.x)으로 핀 고정한다.
+      # `@storybook/*` glob 은 형제 패키지(storybook / eslint-plugin-storybook /
+      # @chromatic-com/storybook)를 매칭하지 못하므로 개별로 함께 막는다.
       - dependency-name: "@storybook/*"
-        update-types: ["version-update:semver-major"]
-      # `@storybook/*` glob does not match the bare `storybook` meta-package.
       - dependency-name: "storybook"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-storybook"
+      - dependency-name: "@chromatic-com/storybook"
       - dependency-name: "cypress"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"


### PR DESCRIPTION
## 배경

dependabot **development-dependencies** 그룹 PR(`development-dependencies-d5080125bb`)의 preview 배포가 `web#test:coverage`에서 실패했습니다.

```
FAIL src/config/next-upgrade.test.ts
 ● Next upgrade guardrails
   Expected: "16.2.6"   Received: "16.2.7"   (@next/env, @next/eslint-plugin-next)
   Expected: "10.4.0"   Received: "10.4.2"   (@storybook/*, storybook, eslint-plugin-storybook)
```

`next-upgrade.test.ts` 가드레일은 Next / Storybook 라인을 **정확한 버전으로 핀 고정**합니다. 그런데 기존 `dependabot.yml` ignore는 다음 허점이 있었습니다.

- `next`, `@storybook/*`, `storybook` → **`semver-major`만** ignore. 이번 같은 **patch bump**는 통과
- `@next/*`(`@next/env`, `@next/eslint-plugin-next`), `eslint-plugin-storybook`, `@chromatic-com/storybook` → **ignore 목록에 아예 없음**

그 결과 patch bump이 가드레일을 깨고 배포를 막았습니다.

## 변경

`.github/dependabot.yml` ignore 정리:

- `next`, `@next/*` → 전체 업데이트 ignore (patch 포함)
- `@storybook/*`, `storybook`, `eslint-plugin-storybook`, `@chromatic-com/storybook` → 전체 업데이트 ignore
  - `@storybook/*` glob이 매칭 못 하는 형제 패키지를 개별로 추가

`react` / `react-dom` / `cypress` / `typescript` / `react-pdf` / `webpack` 등 나머지 ignore 규칙은 그대로 유지했습니다.

## 효과

- dependabot이 Next/Storybook 계열을 더는 자동으로 올리지 않아 가드레일이 깨지지 않습니다.
- 이 계열을 올릴 때는 **수동으로** 버전 정합성을 맞추고 `next-upgrade.test.ts` 기대값을 함께 갱신합니다.
- 기존 `development-dependencies` 그룹 PR은 닫고, dependabot이 Next/Storybook 제외하고 재생성하도록 두면 됩니다.

## 참고

- 런타임 코드 변경 없음. CI 설정(`dependabot.yml`)만 수정.
