### PR TITLE
docs: Project 가이드 문서 수정

### DIFF
--- a/apps/web/src/components/organisms/GuidelineSection/index.tsx
+++ b/apps/web/src/components/organisms/GuidelineSection/index.tsx
@@ -1,5 +1,3 @@
-import clsx from 'clsx';
-
 import SectionTitle from '@/components/atoms/SectionTitle';
 import { DesignerBadge, DeveloperBadge } from '@/lib/assets/logos';
 
@@ -22,7 +20,7 @@ function GuidelineSection() {
             <tr>
               <td className={styles.week}>2주</td>
               <td />
-              <td>사용자 경험 조사</td>
+              <td>기획 고도화</td>
               <td />
             </tr>
             <tr>
@@ -31,31 +29,29 @@ function GuidelineSection() {
               <td>
                 <div className={styles.withBadge}>
                   <DeveloperBadge className={styles.developerBadge} />
-                  <div>프로젝트 세팅</div>
+                  <div>아키텍처 설계</div>
                 </div>
               </td>
               <td>
                 <div className={styles.withBadge}>
                   <DesignerBadge className={styles.designerBadge} />
-                  <div>Lo-fi design</div>
+                  <div>디자인시스템 & 와이어프레임</div>
                 </div>
               </td>
             </tr>
             <tr>
               <td className={styles.week}>4주</td>
-              <td className={styles.middle}>
-                <span className={clsx(styles.badge, styles.absolute)}>중간발표</span>
-              </td>
+              <td />
               <td>
                 <div className={styles.withBadge}>
                   <DeveloperBadge className={styles.developerBadge} />
-                  <div>개발 진행</div>
+                  <div>개발 고도화 미션</div>
                 </div>
               </td>
               <td>
                 <div className={styles.withBadge}>
                   <DesignerBadge className={styles.designerBadge} />
-                  <div>Branding, Hi-fi design</div>
+                  <div>디자인 고도화 미션</div>
                 </div>
               </td>
             </tr>
@@ -68,19 +64,19 @@ function GuidelineSection() {
             <tr>
               <td className={styles.week}>6주</td>
               <td />
-              <td>프로토타입 데모</td>
+              <td>진행상황 점검</td>
               <td />
             </tr>
             <tr>
               <td className={styles.week}>7주</td>
               <td />
-              <td>우선순위 조정</td>
+              <td>최종 발표 및 데모 준비</td>
               <td />
             </tr>
             <tr>
               <td className={styles.week}>8주</td>
               <td>
-                <span className={styles.badge}>🔥최종 발표🔥</span>
+                <span className={styles.badge}>최종 발표</span>
               </td>
               <td />
               <td />


### PR DESCRIPTION
## 변경 사항

Project 활동 가이드라인(`GuidelineSection`)의 주차별 일정 표 내용을 최신 커리큘럼에 맞게 수정했습니다.

| 주차 | 변경 전 | 변경 후 |
| --- | --- | --- |
| 2주 | 사용자 경험 조사 | 기획 고도화 |
| 3주 (개발) | 프로젝트 세팅 | 아키텍처 설계 |
| 3주 (디자인) | Lo-fi design | 디자인시스템 & 와이어프레임 |
| 4주 | 중간발표 뱃지 | (제거) |
| 4주 (개발) | 개발 진행 | 개발 고도화 미션 |
| 4주 (디자인) | Branding, Hi-fi design | 디자인 고도화 미션 |
| 6주 | 프로토타입 데모 | 진행상황 점검 |
| 7주 | 우선순위 조정 | 최종 발표 및 데모 준비 |
| 8주 | 🔥최종 발표🔥 | 최종 발표 |

- 사용하지 않게 된 `clsx` import 제거

## 참고

- 문서/문구 변경만 포함된 PR입니다. (단일 파일: `GuidelineSection/index.tsx`)
