### PR TITLE
fix: 모집 종료 후 알림 버튼을 다음 기수(16기)로 표시

### DIFF
--- a/apps/web/src/lib/assets/data/event_status.json
+++ b/apps/web/src/lib/assets/data/event_status.json
@@ -1,5 +1,5 @@
 {
-  "status": "UPCOMING",
+  "status": "ACTIVE",
   "applicationStartDateTime": "2026/06/01 00:00:00",
   "applicationEndDateTime": "2026/06/14 23:59:59",
   "applicantAcceptanceDateTime": "2026/07/04 00:00:00"


### PR DESCRIPTION
## 변경 사항

`event_status.json`의 `status`를 `UPCOMING` → `ACTIVE`로 변경했습니다.

## 배경

15기 지원 마감일(`2026/06/14`)이 지나면서 `지원하기` 버튼이 사라지고 알림 버튼이 다시 노출되었는데, 라벨이 "16기"가 아니라 "15기 알림 신청하기"로 표시되는 문제가 있었습니다.

원인은 알림 버튼 라벨이 `NEXT_FLAG`를 사용하는데, `NEXT_FLAG = CURRENT_FLAG + (status === 'UPCOMING' ? 0 : 1)` 공식상 status가 여전히 `UPCOMING`이라 `15 + 0 = 15`로 계산되었기 때문입니다.

## 해결

15기 모집이 종료된 현재 상태에 맞춰 `status`를 `ACTIVE`로 변경했습니다.

- `NEXT_FLAG = 15 + 1 = 16` → 알림 버튼이 **"16기 알림 신청하기"** 로 표시됩니다.
- `CURRENT_FLAG`(15)는 그대로 두어 지원하기 / 합격자 조회 / 이탈자 통계 등 다른 표시에는 영향이 없습니다.
- 상단 배지는 일정 기반으로 "07월 04일 (토) 모집 발표 🎄"가 유지됩니다.

## 참고

16기 실제 모집을 오픈할 때는 `CURRENT_FLAG`를 16으로 올리고 폼/시트/일정을 함께 갱신하는 별도 작업(`cohort-open`)이 필요합니다. 이 PR은 "다음 기수 알림" 라벨만 16기로 맞추는 변경입니다.
