### PR TITLE
release: 16기 알림 버튼 표시 수정 배포 (#419)

### DIFF
--- a/apps/web/src/lib/assets/data/event_status.json
+++ b/apps/web/src/lib/assets/data/event_status.json
@@ -1,5 +1,5 @@
 {
-  "status": "UPCOMING",
+  "status": "ACTIVE",
   "applicationStartDateTime": "2026/06/01 00:00:00",
   "applicationEndDateTime": "2026/06/14 23:59:59",
   "applicantAcceptanceDateTime": "2026/07/04 00:00:00"


### PR DESCRIPTION
## 배포 대상

develop → main 배포 PR입니다.

## 포함 변경

- #419 fix: 모집 종료 후 알림 버튼을 다음 기수(16기)로 표시
  - `event_status.json`의 `status`를 `UPCOMING` → `ACTIVE`로 변경
  - 15기 모집 마감 후 알림 버튼이 "15기"로 잘못 표시되던 문제 수정 (`NEXT_FLAG = 15 + 1 = 16` → "16기 알림 신청하기")
  - `CURRENT_FLAG`(15)는 유지되어 지원하기/합격자 조회/통계 표시에는 영향 없음
