### PR TITLE
fix: 합격자 발표일정 및 모집 발표 이모지 수정

### DIFF
--- a/apps/web/src/components/organisms/EventStatus/index.tsx
+++ b/apps/web/src/components/organisms/EventStatus/index.tsx
@@ -49,7 +49,7 @@ function EventStatus({ eventStatus }: Props) {
   }
 
   if (dayjs(currentTime).isBefore(acceptanceDate)) {
-    return <Badge label={`${acceptanceDate.format('MM월 DD일 (ddd)')} 모집 발표 🎄`} variant="success" />;
+    return <Badge label={`${acceptanceDate.format('MM월 DD일 (ddd)')} 모집 발표 📢`} variant="success" />;
   }
 
   if (status === 'ACTIVE') {

--- a/apps/web/src/lib/assets/data/event_status.json
+++ b/apps/web/src/lib/assets/data/event_status.json
@@ -2,5 +2,5 @@
   "status": "ACTIVE",
   "applicationStartDateTime": "2026/06/01 00:00:00",
   "applicationEndDateTime": "2026/06/14 23:59:59",
-  "applicantAcceptanceDateTime": "2026/07/04 00:00:00"
+  "applicantAcceptanceDateTime": "2026/06/27 00:00:00"
 }


### PR DESCRIPTION
## 변경 사항

합격자 발표 관련 오류 수정입니다.

- **합격자 발표일정 수정**: `applicantAcceptanceDateTime` `2026/07/04` → `2026/06/27` 로 정정
- **모집 발표 이모지 수정**: 상단 Badge 문구 이모지 `🎄` → `📢` (발표/공지에 맞게 교체)

## 영향 범위

- `apps/web/src/lib/assets/data/event_status.json`
- `apps/web/src/components/organisms/EventStatus/index.tsx`

홈페이지 상단 이벤트 상태 Badge의 모집 발표일 표기에 반영됩니다.
