### PR TITLE
release: 합격자 발표일정 수정 배포 (#421)

### DIFF
--- a/apps/web/src/components/organisms/EventStatus/index.tsx
+++ b/apps/web/src/components/organisms/EventStatus/index.tsx
@@ -49,7 +49,7 @@ function EventStatus({ eventStatus }: Props) {
   }
 
   if (dayjs(currentTime).isBefore(acceptanceDate)) {
-    return <Badge label={`${acceptanceDate.format('MM월 DD일 (ddd)')} 모집 발표 🎄`} variant="success" />;
+    return <Badge label={`${acceptanceDate.format('MM월 DD일 (ddd)')} 모집 발표 📢`} variant="success" />;
   }
 
   if (status === 'ACTIVE') {

--- a/apps/web/src/lib/assets/data/event_status.json
+++ b/apps/web/src/lib/assets/data/event_status.json
@@ -2,5 +2,5 @@
   "status": "ACTIVE",
   "applicationStartDateTime": "2026/06/01 00:00:00",
   "applicationEndDateTime": "2026/06/14 23:59:59",
-  "applicantAcceptanceDateTime": "2026/07/04 00:00:00"
+  "applicantAcceptanceDateTime": "2026/06/27 00:00:00"
 }


### PR DESCRIPTION
## 배포 대상

develop → main 배포 PR입니다.

## 포함 변경

- #421 fix: 합격자 발표일정 및 모집 발표 이모지 수정
  - `event_status.json`의 `applicantAcceptanceDateTime`를 `2026/07/04` → `2026/06/27`로 정정
  - 상단 이벤트 상태 Badge 모집 발표 문구 이모지 `🎄` → `📢`로 교체
